### PR TITLE
Use `yarn` if installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,9 @@ import { cleanupSync } from "temp";
 
 import { copySync } from "fs-extra";
 
-import { execSync } from "child_process";
-
 import * as logs from "@utils/logs";
 import { program } from "@utils/program";
+import { installPackages } from "@utils/install";
 
 (async (): Promise<void> => {
   clear();
@@ -33,7 +32,7 @@ import { program } from "@utils/program";
 
   logs.installingPackages();
 
-  execSync(`cd ${projectPath} && npm install`);
+  installPackages(projectPath);
 
   logs.finish({
     projectName,

--- a/src/utils/install.ts
+++ b/src/utils/install.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+
+export const useYarn = () => {
+    try {
+        execSync("yarn --version", { stdio: "ignore" });
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+export const installPackages = (path: string) => {
+    const installCommand = useYarn() ? 'yarn install' : 'npm install';
+    execSync(`cd ${path} && ${installCommand}`);
+}


### PR DESCRIPTION
Judging by the `yarn.lock` file in the repo, I thought using `yarn` in cli for installing dependencies would be nice.